### PR TITLE
Enable Direct IM Support for Jidlobot

### DIFF
--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: jidlobot
-          image: ghcr.io/kratochj/jidlobot:v1.0.4
+          image: ghcr.io/kratochj/jidlobot:v1.1.0
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080

--- a/pom.xml
+++ b/pom.xml
@@ -77,12 +77,6 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <version>1.5.12</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/eu/kratochvil/jidlobot/SlackBotService.java
+++ b/src/main/java/eu/kratochvil/jidlobot/SlackBotService.java
@@ -1,6 +1,5 @@
 package eu.kratochvil.jidlobot;
 
-import com.slack.api.app_backend.events.payload.EventsApiPayload;
 import com.slack.api.bolt.App;
 import com.slack.api.bolt.AppConfig;
 import com.slack.api.bolt.context.builtin.EventContext;
@@ -10,8 +9,6 @@ import com.slack.api.methods.SlackApiException;
 import com.slack.api.methods.request.chat.ChatPostMessageRequest;
 import com.slack.api.methods.response.chat.ChatPostMessageResponse;
 import com.slack.api.model.event.AppMentionEvent;
-import com.slack.api.model.event.ImCreatedEvent;
-import com.slack.api.model.event.MessageBotEvent;
 import com.slack.api.model.event.MessageEvent;
 import eu.kratochvil.jidlobot.config.ApplicationConfig;
 import eu.kratochvil.jidlobot.config.SlackConfig;
@@ -97,7 +94,7 @@ public class SlackBotService {
     }
 
     private DailyMenu getMenu() {
-        if(!applicationConfig.isCacheEnabled() || dailyMenu == null || dailyMenuLastUpdated == null
+        if (!applicationConfig.isCacheEnabled() || dailyMenu == null || dailyMenuLastUpdated == null
                 || dailyMenuLastUpdated.isBefore(Instant.now().minusSeconds(applicationConfig.getCacheForSeconds()))) {
             dailyMenu = dailyMenuParser.parse(applicationConfig.getUrl());
             dailyMenuLastUpdated = Instant.now();

--- a/src/main/java/eu/kratochvil/jidlobot/SlackBotService.java
+++ b/src/main/java/eu/kratochvil/jidlobot/SlackBotService.java
@@ -1,12 +1,18 @@
 package eu.kratochvil.jidlobot;
 
+import com.slack.api.app_backend.events.payload.EventsApiPayload;
 import com.slack.api.bolt.App;
 import com.slack.api.bolt.AppConfig;
+import com.slack.api.bolt.context.builtin.EventContext;
 import com.slack.api.bolt.jakarta_socket_mode.SocketModeApp;
+import com.slack.api.bolt.response.Response;
 import com.slack.api.methods.SlackApiException;
 import com.slack.api.methods.request.chat.ChatPostMessageRequest;
 import com.slack.api.methods.response.chat.ChatPostMessageResponse;
 import com.slack.api.model.event.AppMentionEvent;
+import com.slack.api.model.event.ImCreatedEvent;
+import com.slack.api.model.event.MessageBotEvent;
+import com.slack.api.model.event.MessageEvent;
 import eu.kratochvil.jidlobot.config.ApplicationConfig;
 import eu.kratochvil.jidlobot.config.SlackConfig;
 import eu.kratochvil.jidlobot.model.DailyMenu;
@@ -16,6 +22,8 @@ import eu.kratochvil.jidlobot.slack.DailyMenuMessageBuilder;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
@@ -23,6 +31,7 @@ import java.time.Instant;
 
 @Service
 public class SlackBotService {
+    public final static Logger log = LoggerFactory.getLogger(SlackBotService.class);
 
     private final DailyMenuMessageBuilder dailyMenuMessageBuilder;
     private final DailyMenuParser dailyMenuParser;
@@ -53,22 +62,38 @@ public class SlackBotService {
         AppConfig appConfig = AppConfig.builder().singleTeamBotToken(botToken).build();
         App app = new App(appConfig);
 
-        app.event(AppMentionEvent.class, (req, ctx) -> {
-            try {
-                ChatPostMessageRequest message = processCommand(req.getEvent().getText());
-                message.setChannel(ctx.getChannelId());
-                ChatPostMessageResponse responseMenu = ctx.client().chatPostMessage(message);
-                if (!responseMenu.isOk()) {
-                    ctx.logger.error("Error posting message: {}", responseMenu.getError());
-                }
-            } catch (IOException | SlackApiException e) {
-                ctx.logger.error("Exception while posting message: {}", e.getMessage());
-            }
-            return ctx.ack();
-        });
+        app.event(MessageEvent.class, (req, ctx)
+                -> processSlackEvent(true, req.getEvent().getText(), ctx));
+
+        app.event(AppMentionEvent.class, (req, ctx)
+                -> processSlackEvent(false, req.getEvent().getText(), ctx));
 
         socketModeApp = new SocketModeApp(slackConfig.getAppToken(), app);
         socketModeApp.start();
+    }
+
+    private Response processSlackEvent(boolean isIm, String req, EventContext ctx) {
+        try {
+            // Retrieve the user ID of the sender
+            String senderUserId = ctx.getRequestUserId();
+            log.debug("Message received from user: {}", senderUserId);
+
+            // Check if the message was sent by the bot itself
+            if (senderUserId.equals(ctx.getBotUserId())) {
+                log.info("Message ignored as it was sent by the bot itself.");
+                return ctx.ack(); // Acknowledge the event without processing
+            }
+
+            ChatPostMessageRequest message = processCommand(isIm, req);
+            message.setChannel(ctx.getChannelId());
+            ChatPostMessageResponse responseMenu = ctx.client().chatPostMessage(message);
+            if (!responseMenu.isOk()) {
+                log.error("Error posting message: {}", responseMenu.getError());
+            }
+        } catch (IOException | SlackApiException e) {
+            log.error("Exception while posting message: {}", e.getMessage());
+        }
+        return ctx.ack();
     }
 
     private DailyMenu getMenu() {
@@ -80,14 +105,14 @@ public class SlackBotService {
         return dailyMenu;
     }
 
-    private @NotNull ChatPostMessageRequest processCommand(String text) {
+    private @NotNull ChatPostMessageRequest processCommand(boolean isIm, String text) {
         // Remove the bot mention from the text
         String commandText = text.replaceAll("<@\\w+>", "").trim().toLowerCase();
 
         return switch (commandText) {
             case "menu" -> dailyMenuMessageBuilder.getChatPostMessage(getMenu());
-            case "help" -> botMessageBuilder.getChatPostHelpMessage();
-            default -> botMessageBuilder.getChatPostGenericMessage();
+            case "help" -> botMessageBuilder.getChatPostHelpMessage(isIm);
+            default -> botMessageBuilder.getChatPostGenericMessage(isIm);
         };
     }
 

--- a/src/main/java/eu/kratochvil/jidlobot/slack/BotMessageBuilder.java
+++ b/src/main/java/eu/kratochvil/jidlobot/slack/BotMessageBuilder.java
@@ -12,35 +12,53 @@ import java.util.List;
 public class BotMessageBuilder {
 
 
-    public ChatPostMessageRequest getChatPostHelpMessage() {
+    public ChatPostMessageRequest getChatPostHelpMessage(boolean isIm) {
         return ChatPostMessageRequest.builder()
-                .blocks(buildFormattedHelpMessage())
-                .text(buildPlainHelpMessage())
+                .blocks(buildFormattedHelpMessage(isIm))
+                .text(buildPlainHelpMessage(isIm))
                 .build();
     }
 
-    private List<LayoutBlock> buildFormattedHelpMessage() {
+    private List<LayoutBlock> buildFormattedHelpMessage(boolean isIm) {
         List<LayoutBlock> blocks = new ArrayList<>();
         blocks.add(SlackTextUtils.buildHeaderLayoutBlock("Dostupné povely"));
-        blocks.add(SlackTextUtils.buildTextLayoutBlock("- @jidlobot menu - vypíše aktuální jídelníček\n- @jidlobot help - tato zpráva"));
+        if (isIm) {
+            blocks.add(SlackTextUtils.buildTextLayoutBlock("- `menu` - vypíše aktuální jídelníček\n- `help` - tato zpráva"));
+        } else {
+            blocks.add(SlackTextUtils.buildTextLayoutBlock("- `@jidlobot menu` - vypíše aktuální jídelníček\n- `@jidlobot help` - tato zpráva"));
+        }
         blocks.add(Blocks.divider());
         blocks.add(SlackTextUtils.buildTextLayoutBlock("Denní menu je automaticky stahováno z webových stránek Jídlovic."));
         return blocks;
     }
-    private String buildPlainHelpMessage(){
-        return "Dostupné příkazy:\n- @jidlobot menu\n- @jidlobot help";
+
+    private String buildPlainHelpMessage(boolean isIm) {
+        if (isIm)
+            return "Dostupné příkazy:\n- `menu`\n- `help`";
+        else
+            return "Dostupné příkazy:\n- `@jidlobot menu`\n- `@jidlobot help`";
     }
 
-    public ChatPostMessageRequest getChatPostGenericMessage() {
-        return ChatPostMessageRequest.builder()
-                .blocks(buildFormattedGenericMessage())
-                .text("Zadej '@jidlobot help' pro dostupné příkazy.")
-                .build();
+    public ChatPostMessageRequest getChatPostGenericMessage(boolean isIm) {
+        if (isIm)
+            return ChatPostMessageRequest.builder()
+                    .blocks(buildFormattedGenericMessage(isIm))
+                    .text("Zadej `help` pro dostupné příkazy.")
+                    .build();
+        else
+            return ChatPostMessageRequest.builder()
+                    .blocks(buildFormattedGenericMessage(isIm))
+                    .text("Zadej `@jidlobot help` pro dostupné příkazy.")
+                    .build();
     }
 
-    private List<LayoutBlock> buildFormattedGenericMessage() {
+    private List<LayoutBlock> buildFormattedGenericMessage(boolean isIm) {
         List<LayoutBlock> blocks = new ArrayList<>();
-        blocks.add(SlackTextUtils.buildTextLayoutBlock("Zadej '@jidlobot help' pro dostupné příkazy."));
+        if (isIm)
+            blocks.add(SlackTextUtils.buildTextLayoutBlock("Zadej `help` pro dostupné příkazy."));
+        else
+            blocks.add(SlackTextUtils.buildTextLayoutBlock("Zadej `@jidlobot help` pro dostupné příkazy."));
+
 
         return blocks;
     }

--- a/src/main/java/eu/kratochvil/jidlobot/slack/DailyMenuMessageBuilder.java
+++ b/src/main/java/eu/kratochvil/jidlobot/slack/DailyMenuMessageBuilder.java
@@ -38,7 +38,7 @@ public class DailyMenuMessageBuilder {
             return;
         }
         menuText.append("- *").append(heading).append("*:\n");
-        for (DailyMenu.MenuItem dish :menuItems) {
+        for (DailyMenu.MenuItem dish : menuItems) {
             menuText.append(String.format("- %s (%s) - %s\n", dish.getName(), dish.getAllergens(), formatPrice(dish.getPrice())));
         }
     }
@@ -74,7 +74,11 @@ public class DailyMenuMessageBuilder {
         blocks.add(SlackTextUtils.buildTextLayoutBlock(String.format("*%s*", heading)));
 
         for (DailyMenu.MenuItem menuItem : menuItems) {
-            String menuItemText = String.format("• %s (%s) - %s", menuItem.getName(), menuItem.getAllergens(), formatPrice(menuItem.getPrice()));
+            String menuItemText;
+            if (menuItem.getPrice() == 0)
+                menuItemText = String.format("• %s (%s)", menuItem.getName(), menuItem.getAllergens());
+            else
+                menuItemText = String.format("• %s (%s) - %s", menuItem.getName(), menuItem.getAllergens(), formatPrice(menuItem.getPrice()));
             blocks.add(SlackTextUtils.buildTextLayoutBlock(menuItemText));
         }
         return blocks;


### PR DESCRIPTION
This pull request introduces a major feature enhancement: **users can now send direct messages (IM) to Jidlobot in Slack**, enabling a faster and more personalized experience. Other changes included in this update are minor or cosmetic improvements.  

### 🌟 **Direct IM Support for Jidlobot**  🎉

- Users can now interact with Jidlobot via Slack **direct messages (IM)**, in addition to group mentions.  
- Updated `BotMessageBuilder` to handle both direct and group messages using a boolean flag (`isIm`).  
- Enhanced `SlackBotService` to differentiate between direct messages and channel mentions, ensuring precise processing.  
- Implemented safeguards to ignore messages sent by the bot itself, avoiding redundant handling.  
- Added logging to track and debug message handling effectively.  

---

### Minor Changes:  

1. **Remove Logback Dependency from Test Scope**  
   - Eliminated `Logback Classic` from `pom.xml` to reduce unnecessary logging during tests.

2. **Remove Unused Imports and Improve Formatting**  
   - Cleaned up unused imports and improved code readability without affecting functionality.  

3. **Improve Menu Messaging Format**  
   - Fixed spacing issues and excluded zero-price items for cleaner Slack notifications.  

4. **Bump jidlobot Image to Version v1.1.0**  
   - Upgraded container image in Kubernetes deployment to use the latest version (`v1.1.0`).  

---

**Impact:**  
- **Empowers users to interact with Jidlobot directly via Slack IM**, simplifying the user experience.  
- Ensures cleaner code, improved formatting, and minor fixes for better overall maintainability.  
